### PR TITLE
solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "test:only": "mate-scripts test",
     "update": "mate-scripts update",
     "postinstall": "npm run update",
-    "test": "npm run lint && npm run test:only"
+    "test": "npm run lint && npm run test:only",
+    "copy": "node ./src/app.js"
   },
   "author": "Mate academy",
   "license": "GPL-3.0",
   "devDependencies": {
     "@mate-academy/eslint-config": "*",
-    "@mate-academy/scripts": "^0.9.7",
+    "@mate-academy/scripts": "^1.2.9",
     "eslint": "^5.16.0",
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-node": "^8.0.1",

--- a/readme.md
+++ b/readme.md
@@ -6,3 +6,10 @@ Write an app that will copy a file from one specified location to another like
 Linux cp command: `cp file.txt file-copy.txt`.
 - It must do nothing in case the user is trying to copy to the same location.
 - The app must support only copying of files, and no additional options (flags). Plain copying of files.
+
+
+
+
+  How to use:
+  - run `node <path> /app.js arg_1 arg_2` or `npm run copy arg_1 arg_2` in root folder.
+- The first argument is the source path like `./folder/file.name` and the second - is the destination folder. It can be copied between drivers: `/<driver name>/<rest path>` or `<driver name>:/<rest path>`.

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,6 @@ Linux cp command: `cp file.txt file-copy.txt`.
 
 
 
-  How to use:
+  ## How to use:
   - run `node <path> /app.js arg_1 arg_2` or `npm run copy arg_1 arg_2` in root folder.
 - The first argument is the source path like `./folder/file.name` and the second - is the destination folder. It can be copied between drivers: `/<driver name>/<rest path>` or `<driver name>:/<rest path>`.

--- a/src/app.js
+++ b/src/app.js
@@ -1,1 +1,34 @@
 'use strict';
+
+/* eslint no-console: ["error", { allow: ["log"] }] */
+
+const fs = require('fs');
+const path = require('path');
+
+const copy = () => {
+  const args = process.argv.slice(2);
+  const sourcePath = path.join(path.join(process.cwd()), args[0]);
+  let destPath = path.join(path.join(process.cwd()), args[1]);
+
+  if (destPath.includes(':')) {
+    destPath = args[1];
+  }
+
+  const lastBackslachIndex = sourcePath.lastIndexOf('\\');
+  const clearedSourcePath = sourcePath.slice(0, lastBackslachIndex + 1);
+  const destPathWithFileName = destPath + sourcePath.slice(lastBackslachIndex);
+
+  if (clearedSourcePath === destPath) {
+    return;
+  }
+
+  fs.copyFile(sourcePath, destPathWithFileName, (err) => {
+    if (err) {
+      console.log('Error Found:', err);
+    } else {
+      console.log(`Successfully copied to ${destPathWithFileName}`);
+    }
+  });
+};
+
+copy();


### PR DESCRIPTION
Hi,

  #### How to use:
  - run `node <path> /app.js arg_1 arg_2` or `npm run copy arg_1 arg_2` in root folder.
- The first argument is the source path like `./folder/file.name` and the second - is the destination folder. It can be copied between drivers: `/<driver name>/<rest path>` or `<driver name>:/<rest path>`.